### PR TITLE
support Node 0.10 by using a `buffer.equals` polyfill

### DIFF
--- a/detect.js
+++ b/detect.js
@@ -1,3 +1,4 @@
+var bufferEquals = require("buffer-equals")
 var magicNumbers = {
   zip: new Buffer("504B0304", "hex"),
   tar: new Buffer("7573746172", "hex"),
@@ -12,13 +13,13 @@ module.exports = {
 }
 
 function isZip (data) {
-  return data.slice(0, 4).equals(magicNumbers.zip)
+  return bufferEquals(data.slice(0, 4), magicNumbers.zip)
 }
 
 function isTar (data) {
-  return data.slice(257, 262).equals(magicNumbers.tar)
+  return bufferEquals(data.slice(257, 262), magicNumbers.tar)
 }
 
 function isTarGz (data) {
-  return data.slice(0, 3).equals(magicNumbers.targz)
+  return bufferEquals(data.slice(0, 3), magicNumbers.targz)
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/maxogden/extracto#readme",
   "dependencies": {
+    "buffer-equals": "^1.0.3",
     "extract-zip": "^1.0.3",
     "gunzip-maybe": "^1.1.0",
     "peek-stream": "^1.1.1",


### PR DESCRIPTION
`buffer.equals` didn't exist in Node 0.10.

https://github.com/sindresorhus/buffer-equals
